### PR TITLE
Fix Gemini response MIME type to avoid INVALID_ARGUMENT

### DIFF
--- a/dip_gemini_app.py
+++ b/dip_gemini_app.py
@@ -146,6 +146,16 @@ class DipClient:
 # ----------------------
 # Gemini Client Wrapper
 # ----------------------
+ALLOWED_GEMINI_RESPONSE_MIME_TYPES = {
+    "text/plain",
+    "application/json",
+    "application/xml",
+    "application/yaml",
+    "text/x.enum",
+}
+DEFAULT_GEMINI_MIME_TYPE = "text/plain"
+
+
 class GeminiClient:
     def __init__(self, api_key: str, model: str):
         self.api_key = api_key.strip()
@@ -156,7 +166,14 @@ class GeminiClient:
             )
         self.client = genai.Client(api_key=self.api_key) if self.api_key else genai.Client()
 
-    def generate(self, prompt: str, system_instruction: str, mime: str = "text/markdown") -> str:
+    def generate(
+        self,
+        prompt: str,
+        system_instruction: str,
+        mime: str = DEFAULT_GEMINI_MIME_TYPE,
+    ) -> str:
+        if mime not in ALLOWED_GEMINI_RESPONSE_MIME_TYPES:
+            mime = DEFAULT_GEMINI_MIME_TYPE
         try:
             cfg = (
                 genai_types.GenerateContentConfig(


### PR DESCRIPTION
## Summary
- default the Gemini client to the allowed `text/plain` response MIME type
- guard against unsupported MIME selections when generating content

## Testing
- python -m compileall dip_gemini_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cab3d4d54c8322a66da5132136e639